### PR TITLE
[COOK-1234] add ports and port_range attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Tested on:
 
 * Ubuntu 10.04
 * Ubuntu 11.04
+* Ubuntu 11.10
 
 Resources/Providers
 ===================
@@ -69,6 +70,8 @@ Resources/Providers
 - name: name attribute. arbitrary name to uniquely identify this firewall rule
 - protocol: valid values are: :udp, :tcp. default is all protocols
 - port: incoming port number (ie. 22 to allow inbound SSH)
+- ports: array of incoming port numbers (ie. [80,443] to allow inbound HTTP & HTTPS)
+- port_range: range of incoming port numbers (ie. 60000..61000 to allow inbound mobile-shell)
 - source: ip address or subnet to filter on incoming traffic. default is `0.0.0.0/0` (ie Anywhere)
 - destination: ip address or subnet to filter on outgoing traffic.
 - dest_port: outgoing port number.
@@ -105,6 +108,13 @@ Resources/Providers
       source '10.0.111.0/24'
       direction 'in'
       interface 'eth0'
+      action :allow
+    end
+
+    # open UDP ports 60000..61000 for mobile shell (mosh.mit.edu)
+    firewall_rule "mosh" do
+      protocol :udp
+      port_range 60000..61000
       action :allow
     end
 

--- a/providers/rule_ufw.rb
+++ b/providers/rule_ufw.rb
@@ -62,7 +62,13 @@ def apply_rule(type=nil)
     else
       ufw_command << "to any "
     end
-    ufw_command << "port #{@new_resource.port} " if @new_resource.port
+    if @new_resource.port
+      ufw_command << "port #{@new_resource.port} "
+    elsif @new_resource.ports
+      ufw_command << "port #{@new_resource.ports.join(',')} "
+    elsif @new_resource.port_range
+      ufw_command << "port #{@new_resource.port_range.first}:#{@new_resource.port_range.last} "
+    end
 
     Chef::Log.debug("ufw: #{ufw_command}")
     shell_out!(ufw_command)

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -23,6 +23,8 @@ IP_CIDR_VALID_REGEX = /\b(?:\d{1,3}\.){3}\d{1,3}\b(\/[0-3]?[0-9])?/
 actions :allow, :deny, :reject
 
 attribute :port, :kind_of => Integer
+attribute :ports, :kind_of => Array
+attribute :port_range, :kind_of => Range
 attribute :protocol, :kind_of => Symbol, :equal_to => [ :udp, :tcp ]
 attribute :direction, :kind_of => Symbol, :equal_to => [ :in, :out ]
 attribute :interface, :kind_of => String


### PR DESCRIPTION
This adds the ability to specify multiple ports per firewall rule, either as an array (ports) or a range (port_range). I created COOK-1234 as the corresponding ticket for this.
