### PR TITLE
Fix for COOK-1615

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Resources/Providers
     firewall_rule "myapplication" do
       port 13579
       source '10.0.111.0/24'
-      direction 'in'
+      direction :in
       interface 'eth0'
       action :allow
     end


### PR DESCRIPTION
Direction should be a symbol not a string.
