### PR TITLE
Add 'default' attribute to firewall resource for setting default behavior for incoming connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Resources/Providers
 ### Attribute Parameters
 
 - name: name attribute. arbitrary name to uniquely identify this resource
+- default: default behavior on all incoming connections. valid values are: :allow, :deny.
 - log_level: level of verbosity the firewall should log at. valid values are: :low, :medium, :high, :full. default is :low.
 
 ### Providers
@@ -52,6 +53,12 @@ Resources/Providers
     # increase logging past default of 'low'
     firewall "debug firewalls" do
       log_level :high
+      action :enable
+    end
+
+    # allow all incoming connections by default
+    firewall "open" do
+      default :allow
       action :enable
     end
 

--- a/providers/ufw.rb
+++ b/providers/ufw.rb
@@ -28,6 +28,11 @@ action :enable do
       shell_out!("ufw logging #{@new_resource.log_level}") 
       Chef::Log.info("#{@new_resource} logging enabled at '#{@new_resource.log_level}' level")
     end
+
+    if @new_resource.default
+      shell_out!("ufw default #{@new_resource.default}")
+      Chef::Log.info("#{@new_resource} default mode at '#{@new_resource.default}'")
+    end
     new_resource.updated_by_last_action(true)
   else
     Chef::Log.debug("#{@new_resource} already enabled.")

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -20,6 +20,7 @@
 
 actions :enable, :disable
 
+attribute :default, :kind_of => Symbol, :equal_to => [:allow, :deny], :default => :deny
 attribute :log_level, :kind_of => Symbol, :equal_to => [:low, :medium, :high, :full], :default => :low
 
 def initialize(name, run_context=nil)


### PR DESCRIPTION
Because sometimes you need to set the default behavior for all incoming connections. `:deny` is the default.

This capability is documented here: https://help.ubuntu.com/community/UFW
