### PR TITLE
[COOK-2932] debian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ Platform
 --------
 
 * Ubuntu
+* Debian
 
 Tested on:
 
 * Ubuntu 10.04
 * Ubuntu 11.04
 * Ubuntu 11.10
+* Debian 7.0
 
 Resources/Providers
 ===================

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -30,9 +30,11 @@ end
 
 private
 def set_platform_default_providers
-  Chef::Platform.set(
-    :platform => :ubuntu,
-    :resource => :firewall,
-    :provider => Chef::Provider::FirewallUfw
-  )
+  [:ubuntu, :debian].each do |platform|
+    Chef::Platform.set(
+      :platform => platform,
+      :resource => :firewall,
+      :provider => Chef::Provider::FirewallUfw
+    )
+  end
 end

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -42,9 +42,11 @@ end
 
 private
 def set_platform_default_providers
-  Chef::Platform.set(
-    :platform => :ubuntu,
-    :resource => :firewall_rule,
-    :provider => Chef::Provider::FirewallRuleUfw
-  )
+  [:ubuntu, :debian].each do |platform|
+    Chef::Platform.set(
+        :platform => platform,
+        :resource => :firewall_rule,
+        :provider => Chef::Provider::FirewallRuleUfw
+    )
+  end
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2932

Tested the FirewallRuleUfw and FirewallUfw on debian 7. They work properly but could not be used because they were not Chef::Platform.set for debian.

This pull request allows debian users to use ufw providers
