### PR TITLE
[COOK-4140] Only notify when a rule is actually added

### DIFF
--- a/providers/rule_ufw.rb
+++ b/providers/rule_ufw.rb
@@ -25,7 +25,9 @@ end
 include Chef::Mixin::ShellOut
 
 action :allow do
-  unless rule_exists?
+  if rule_exists?
+    Chef::Log.debug "Rule #{rule} already allowed - skipping"
+  else
     converge_by("Allowing #{rule}") do
       apply_rule('allow')
     end
@@ -33,7 +35,9 @@ action :allow do
 end
 
 action :deny do
-  unless rule_exists?
+  if rule_exists?
+    Chef::Log.debug "Rule #{rule} already denied - skipping"
+  else
     converge_by("Denying #{rule}") do
       apply_rule('deny')
     end
@@ -41,7 +45,9 @@ action :deny do
 end
 
 action :reject do
-  unless rule_exists?
+  if rule_exists?
+    Chef::Log.debug "Rule #{rule} already rejected - skipping"
+  else
     converge_by("Rejecting #{rule}") do
       apply_rule('reject')
     end


### PR DESCRIPTION
This fixes the `rule` resource to only notify whenever a rule is actually added.  This is done by using the `rule_exists?` method as a condition for convergence.  I also tried to improve the existence checks based on [COOK-3944](https://tickets.opscode.com/browse/COOK-3944) and [COOK-1070](https://tickets.opscode.com/browse/COOK-1070).

https://tickets.opscode.com/browse/COOK-4140
