### PR TITLE
Convert port to string to avoid Regexp error.

### DIFF
--- a/providers/rule_ufw.rb
+++ b/providers/rule_ufw.rb
@@ -137,7 +137,7 @@ def rule_exists?
   if @new_resource.protocol && @new_resource.port
     to << "#{Regexp.escape("#{@new_resource.port}/#{@new_resource.protocol}")}\s"
   elsif @new_resource.port
-    to << "#{Regexp.escape(@new_resource.port)}\s"
+    to << "#{Regexp.escape(@new_resource.port.to_s)}\s"
   end
   if to.empty?
     to << "Anywhere\s"


### PR DESCRIPTION
I needed to update this in order to have it work on my system.
