### PR TITLE
Make the cookbook blow up

### DIFF
--- a/test/fixtures/cookbooks/fake/recipes/default.rb
+++ b/test/fixtures/cookbooks/fake/recipes/default.rb
@@ -1,3 +1,8 @@
 firewall 'ufw' do
   action :enable
 end
+
+firewall_rule 'ssh' do
+  port 22
+  action :allow
+end


### PR DESCRIPTION
This should make the cookbook blow up, as of 0.11.4.  22 errors out as fixnum can't be converted to a string to be regex'ed.
