### PR TITLE
[COOK-4385] Class type conversion

### DIFF
--- a/providers/rule_ufw.rb
+++ b/providers/rule_ufw.rb
@@ -137,7 +137,7 @@ def rule_exists?
   if @new_resource.protocol && @new_resource.port
     to << "#{Regexp.escape("#{@new_resource.port}/#{@new_resource.protocol}")}\s"
   elsif @new_resource.port
-    to << "#{Regexp.escape("#{@new_resource.port}")\s"
+    to << "#{Regexp.escape("#{@new_resource.port}")}\s"
   end
   if to.empty?
     to << "Anywhere\s"


### PR DESCRIPTION
Regex.Escape method accepts only a string parameter.  Port is a fixnum.

Rather than do a .to_s, put it in quotes to keep syntax consistent in code block.
