### PR TITLE
[COOK-4385] Class Type Conversion

### DIFF
--- a/providers/rule_ufw.rb
+++ b/providers/rule_ufw.rb
@@ -137,7 +137,7 @@ def rule_exists?
   if @new_resource.protocol && @new_resource.port
     to << "#{Regexp.escape("#{@new_resource.port}/#{@new_resource.protocol}")}\s"
   elsif @new_resource.port
-    to << "#{Regexp.escape(@new_resource.port)}\s"
+    to << "#{Regexp.escape("#{@new_resource.port}")}\s"
   end
   if to.empty?
     to << "Anywhere\s"


### PR DESCRIPTION
The Regexp.Escape method accepts a string parameter.  Port is a fixnum.  Must be converted here.

Kept in-line with prior syntax of using quotes rather than .to_s method.
