### PR TITLE
[COOK-4648] rule_exists? checks rule direction

### DIFF
--- a/providers/rule_ufw.rb
+++ b/providers/rule_ufw.rb
@@ -149,7 +149,11 @@ def rule_exists?
   from = ''
   from << "#{Regexp.escape(@new_resource.source || 'Anywhere')}"
 
-  regex = /^#{to}.*#{action}.*#{from}.*$/
+  if @new_resource.direction == :out
+    regex = /^#{to}.*#{action}OUT\s.*#{from}.*$/
+  else
+    regex = /^#{to}.*#{action}.*#{from}.*$/
+  end
 
   match = shell_out!('ufw status').stdout.lines.find do |line|
     # TODO: support IPv6


### PR DESCRIPTION
If the new rule direction is out, the regex for checking the rule is
already applied verifies with the Action regex set to "ALLOW OUT" so
it's not checked against an incoming rule.
