### PR TITLE
Fixing #207 - only try to install iptables-ipv6 package if CentOS 6

### DIFF
--- a/libraries/helpers_iptables.rb
+++ b/libraries/helpers_iptables.rb
@@ -49,7 +49,7 @@ module FirewallCookbook
       end
 
       def iptables_packages(new_resource)
-        packages = if ipv6_enabled?(new_resource)
+        packages = if ipv6_enabled?(new_resource) && node['platform_family'] == 'centos' && node['platform_version'].to_i == 6
                      %w(iptables iptables-ipv6)
                    else
                      %w(iptables)


### PR DESCRIPTION
### Description

See issue #207, the `iptables-ipv6` package is trying to be installed anytime the following 3 conditions are true: ipv6 enabled, iptables enabled, not Debian. The problem is this package only exists for CentOS 6, all other distros bundle v6 functionality in the standard `iptables` package. Trying to install `iptables-ipv6` on other distros causes the chef run to fail. This fixes that, only installing it if we're on CentOS 6.

This has been tested working on Fedora 28. I haven't tested on any other distros, and don't have the time to do so. This PR is provided as-is.

### Issues Resolved

#207 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
