### PR TITLE
[GH-253] Add filepath selection based on OS for nftables.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the firewall cookbook.
 
 ## Unreleased
 
+- Add filepath selection based on OS for nftables.conf
+
 ## 6.0.2 - *2022-05-15*
 
 Standardise files with files in sous-chefs/repo-management

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Tested on:
 - Debian 11 with new resources for firewalld
 - CentOS 6 with iptables
 - CentOS 7.1 with firewalld
+- Oracle 8 with nftables
 - Windows Server 2012r2 with Windows Advanced Firewall
 
 By default, Ubuntu chooses ufw. To switch to iptables, set this in an attribute file:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -33,6 +33,7 @@ platforms:
   - name: freebsd-11
   - name: freebsd-12
   - name: opensuse-leap-15
+  - name: oracle-8
   - name: ubuntu-18.04
   - name: ubuntu-20.04
   - name: windows-2016
@@ -54,6 +55,7 @@ suites:
       - centos-8
       - debian-9
       - debian-10
+      - oracle-8
       - ubuntu-18.04
       - ubuntu-20.04
       - windows-2016
@@ -72,6 +74,7 @@ suites:
       - freebsd-11
       - freebsd-12
       - opensuse-leap-15
+      - oracle-8
       - windows-2016
       - windows-2019
     run_list:
@@ -82,6 +85,7 @@ suites:
     excludes:
       - debian-9
       - debian-10
+      - oracle-8
       - ubuntu-18.04
       - ubuntu-20.04
       - windows-2016
@@ -97,6 +101,7 @@ suites:
   - name: nftables
     includes:
       - debian-11
+      - oracle-8
     run_list:
       - recipe[nftables-test]
 

--- a/libraries/helpers_nftables.rb
+++ b/libraries/helpers_nftables.rb
@@ -154,6 +154,17 @@ module FirewallCookbook
         input = new_resource.rules || {}
         input.merge!(default_ruleset(new_resource))
       end
+
+      def nftables_conf_location
+        case node['platform_family']
+        when 'rhel'
+          '/etc/sysconfig/nftables.conf'
+        when 'debian'
+          '/etc/nftables.conf'
+        else
+          raise "nftables_conf_location: Unsupported platform #{node['platform']}."
+        end
+      end
     end
   end
 end

--- a/libraries/helpers_nftables.rb
+++ b/libraries/helpers_nftables.rb
@@ -155,14 +155,14 @@ module FirewallCookbook
         input.merge!(default_ruleset(new_resource))
       end
 
-      def nftables_conf_location
+      def default_nftables_conf_path
         case node['platform_family']
         when 'rhel'
           '/etc/sysconfig/nftables.conf'
         when 'debian'
           '/etc/nftables.conf'
         else
-          raise "nftables_conf_location: Unsupported platform #{node['platform']}."
+          raise "default_nftables_conf_path: Unsupported platform_family #{node['platform_family']}."
         end
       end
     end

--- a/resources/nftables.rb
+++ b/resources/nftables.rb
@@ -40,7 +40,7 @@ end
 action :rebuild do
   ensure_default_rules_exist(new_resource)
 
-  file '/etc/nftables.conf' do
+  file nftables_conf_location do
     content  <<~NFT
       #!/usr/sbin/nft -f
       flush ruleset

--- a/resources/nftables.rb
+++ b/resources/nftables.rb
@@ -1,9 +1,7 @@
 unified_mode true
 
-action_class do
-  include FirewallCookbook::Helpers
-  include FirewallCookbook::Helpers::Nftables
-end
+include FirewallCookbook::Helpers
+include FirewallCookbook::Helpers::Nftables
 
 provides :nftables,
          os: 'linux'
@@ -29,6 +27,9 @@ property :table_ip_nat,
 property :table_ip6_nat,
          [true, false],
          default: false
+property :nftables_conf_path, String,
+         description: 'nftables.conf filepath',
+         default: lazy { default_nftables_conf_path }
 
 action :install do
   package 'nftables' do
@@ -40,7 +41,7 @@ end
 action :rebuild do
   ensure_default_rules_exist(new_resource)
 
-  file nftables_conf_location do
+  file new_resource.nftables_conf_path do
     content  <<~NFT
       #!/usr/sbin/nft -f
       flush ruleset

--- a/test/integration/nftables/inspec/nftables_spec.rb
+++ b/test/integration/nftables/inspec/nftables_spec.rb
@@ -38,3 +38,11 @@ describe service('nftables') do
   it { should be_enabled }
   it { should be_running }
 end
+
+describe file('/etc/sysconfig/nftables.conf') do
+  it { should exist }
+end if os.redhat?
+
+describe file('/etc/nftables.conf') do
+  it { should exist }
+end if os.debian?


### PR DESCRIPTION
# Description

Updates nftables recipe to support Oracle Linux 8 file paths.

## Issues Resolved

[GH-253]

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
