### PR TITLE
Update GitHub actions to use checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: kitchen

--- a/.github/workflows/md-links.yml
+++ b/.github/workflows/md-links.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: markdown-link-check
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:


### PR DESCRIPTION
# Description

This updates the version of the checkout action used as checkout@v2 uses Node.js 12 which is now deprecated. This avoids GitHub actions warnings like this.

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2

## Issues Resolved

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.

I didn't add a CHANGELOG entry as this is an infrastructural change to CI, not to the firewall cookbook.

Also, until #256 is merged and the lint issues at the HEAD of main currently are resolved, this will fail the CI lint check.