### PR TITLE
Fix Typo in Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the firewall cookbook.
 
 ## Unreleased
 
+Fixed a typo in the readme
+
 ## 6.2.10 - *2023-04-01*
 
 ## 6.2.9 - *2023-04-01*

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ end
    - `:allow` (_default action_): the rule should allow matching packets
    - `:deny`: the rule should deny matching packets
    - `:reject`: the rule should reject matching packets
-   - `:masqerade`: Masquerade the matching packets
+   - `:masquerade`: Masquerade the matching packets
    - `:redirect`: Redirect the matching packets
    - `:log`: Configure logging
 - `stateful`: a symbol or array of symbols, such as ``[:related, :established]` that will be passed to the state module in iptables or firewalld.


### PR DESCRIPTION
# Description

Fixed a typo in the readme that was fixed in code in 2015.

## Issues Resolved

None.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
