### PR TITLE
fix typo in nftables default ruleset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the firewall cookbook.
 
 ## Unreleased
 
+Fixes typo in FORWARD chain of nftables default ruleset
+
 ## 6.2.17 - *2023-07-10*
 
 ## 6.2.16 - *2023-05-17*

--- a/libraries/helpers_nftables.rb
+++ b/libraries/helpers_nftables.rb
@@ -135,7 +135,7 @@ module FirewallCookbook
           'add table inet filter' => 1,
           "add chain inet filter INPUT { type filter hook input priority 0 ; policy #{new_resource.input_policy}; }" => 2,
           "add chain inet filter OUTPUT { type filter hook output priority 0 ; policy #{new_resource.output_policy}; }" => 2,
-          "add chain inet filter FOWARD { type filter hook forward priority 0 ; policy #{new_resource.forward_policy}; }" => 2,
+          "add chain inet filter FORWARD { type filter hook forward priority 0 ; policy #{new_resource.forward_policy}; }" => 2,
         }
         if new_resource.table_ip_nat
           rules['add table ip nat'] = 1


### PR DESCRIPTION
# Description

Fixes typo in FORWARD chain of nftables default ruleset.

## Issues Resolved

Currently no open issue.

## Check List

- [X] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
