### PR TITLE
fix port sorting in generated firewall rules file

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -11,7 +11,7 @@ module FirewallCookbook
         p.to_s
       elsif p && p.is_a?(Array)
         p_strings = p.map { |o| port_to_s(o) }
-        p_strings.sort.join(',')
+        p_strings.sort_by { |s| s.scan(/\d+/).first.to_i }.join(',')
       elsif p && p.is_a?(Range)
         if platform_family?('windows')
           "#{p.first}-#{p.last}"


### PR DESCRIPTION
# Description

given ports parameter als array of strings i.e:
```ruby
firewall_rule 'allow some ports' do
  port %w(80 88 389 443 464 636)
  source '10.10.10.10'
end
```

generates in `/etc/default/ufw-chef.rules` file:
`ufw allow in proto tcp to any port 389,443,464,636,80,88 from 10.10.10.10 comment "allow some ports"`

after this fix:
`ufw allow in proto tcp to any port 80,88,389,443,464,636 from 10.10.10.10 comment "allow some ports"`

## Issues Resolved

Correct generation of firewall rules.

## Check List

- [-] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [-] New functionality includes testing.
- [-] New functionality has been documented in the README if applicable.
