### PR TITLE
Fixed: missing default protocol when using dest_port property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the firewall cookbook.
 
 ## Unreleased
 
+### Fixed
+
+- `firewall_rule` doesn't default protocol to `tcp` when using `dest_port` property.
+
 ## 7.0.0 - *2025-01-03*
 
 ### Summary

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,9 +1,7 @@
 driver:
   name: dokken
   privileged: true
-  # Latest Chef container (18.6.2) is broken: https://github.com/chef/chef/issues/14760
-  # chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
-  chef_version: '18.3'
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
   intermediate_instructions:
     - | # Need to set "IPv6_rpfilter=no" otherwise firewalld won't start inside Docker container
         RUN mkdir -p /etc/firewalld && \

--- a/resources/firewall_rule_firewalld.rb
+++ b/resources/firewall_rule_firewalld.rb
@@ -45,7 +45,7 @@ action :create do
     deny: :drop,
   }
 
-  protocol_required = property_is_set?(:protocol) || property_is_set?(:port) | property_is_set?(:source_port)
+  protocol_required = property_is_set?(:protocol) || property_is_set?(:port) | property_is_set?(:dest_port) | property_is_set?(:source_port)
   array_property = check_for_port_array_property(new_resource)
 
   if array_property

--- a/test/fixtures/cookbooks/firewall-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/default.rb
@@ -37,6 +37,16 @@ firewall_rule 'ssh2222' do
   command :allow
 end
 
+firewall_rule 'dest_port' do
+  dest_port 25
+  command :allow
+end
+
+firewall_rule 'source_port' do
+  source_port 31000
+  command :allow
+end
+
 # other rules
 firewall_rule 'temp1' do
   port 1234


### PR DESCRIPTION
# Description

Fixes an issue where the `firewall_rule` resource doesn't default the protocol to `tcp` when using the `dest_port` property.

## Issues Resolved

Fixes #307 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
