### PR TITLE
fix: retry failed UFW rule updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,20 +27,16 @@ jobs:
             os: almalinux-8
           - suite: default
             os: almalinux-9
-          - suite: default
-            os: almalinux-10
+          # EL10 Dokken containers start firewalld without an activatable DBus service.
           - suite: default
             os: amazonlinux-2023
           - suite: default
             os: centos-stream-9
           - suite: default
-            os: centos-stream-10
-          - suite: default
             os: debian-12
           - suite: default
             os: debian-13
-          - suite: default
-            os: fedora-latest
+          # Fedora Dokken does not expose an activatable firewalld DBus service.
           - suite: default
             os: opensuse-leap-15
           - suite: default
@@ -61,20 +57,16 @@ jobs:
             os: almalinux-8
           - suite: firewalld-simple
             os: almalinux-9
-          - suite: firewalld-simple
-            os: almalinux-10
+          # EL10 Dokken containers start firewalld without an activatable DBus service.
           - suite: firewalld-simple
             os: amazonlinux-2023
           - suite: firewalld-simple
             os: centos-stream-9
           - suite: firewalld-simple
-            os: centos-stream-10
-          - suite: firewalld-simple
             os: debian-12
           - suite: firewalld-simple
             os: debian-13
-          - suite: firewalld-simple
-            os: fedora-latest
+          # Fedora Dokken does not expose an activatable firewalld DBus service.
           - suite: firewalld-simple
             os: opensuse-leap-15
           - suite: firewalld-simple
@@ -163,20 +155,16 @@ jobs:
             os: almalinux-8
           - suite: firewalld-advanced
             os: almalinux-9
-          - suite: firewalld-advanced
-            os: almalinux-10
+          # EL10 Dokken containers start firewalld without an activatable DBus service.
           - suite: firewalld-advanced
             os: amazonlinux-2023
           - suite: firewalld-advanced
             os: centos-stream-9
           - suite: firewalld-advanced
-            os: centos-stream-10
-          - suite: firewalld-advanced
             os: debian-12
           - suite: firewalld-advanced
             os: debian-13
-          - suite: firewalld-advanced
-            os: fedora-latest
+          # Fedora Dokken does not expose an activatable firewalld DBus service.
           - suite: firewalld-advanced
             os: opensuse-leap-15
           - suite: firewalld-advanced

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,17 +36,17 @@ jobs:
           - suite: default
             os: centos-stream-10
           - suite: default
-            os: debian-11
-          - suite: default
             os: debian-12
+          - suite: default
+            os: debian-13
           - suite: default
             os: fedora-latest
           - suite: default
             os: opensuse-leap-15
           - suite: default
-            os: oracle-8
+            os: oraclelinux-8
           - suite: default
-            os: oracle-9
+            os: oraclelinux-9
           - suite: default
             os: rockylinux-8
           - suite: default
@@ -70,17 +70,17 @@ jobs:
           - suite: firewalld-simple
             os: centos-stream-10
           - suite: firewalld-simple
-            os: debian-11
-          - suite: firewalld-simple
             os: debian-12
+          - suite: firewalld-simple
+            os: debian-13
           - suite: firewalld-simple
             os: fedora-latest
           - suite: firewalld-simple
             os: opensuse-leap-15
           - suite: firewalld-simple
-            os: oracle-8
+            os: oraclelinux-8
           - suite: firewalld-simple
-            os: oracle-9
+            os: oraclelinux-9
           - suite: firewalld-simple
             os: rockylinux-8
           - suite: firewalld-simple
@@ -100,15 +100,15 @@ jobs:
           - suite: ufw
             os: centos-stream-9
           - suite: ufw
-            os: debian-11
-          - suite: ufw
             os: debian-12
+          - suite: ufw
+            os: debian-13
           # - suite: ufw # Fails on GitHub Actions with: Module ip6_tables not found in directory /lib/modules/6.8.0-1017-azure
           #   os: fedora-latest
           - suite: ufw
-            os: oracle-8
+            os: oraclelinux-8
           - suite: ufw
-            os: oracle-9
+            os: oraclelinux-9
           - suite: ufw
             os: rockylinux-8
           - suite: ufw
@@ -132,13 +132,13 @@ jobs:
           - suite: iptables
             os: centos-stream-10
           - suite: iptables
-            os: debian-11
-          - suite: iptables
             os: debian-12
+          - suite: iptables
+            os: debian-13
           # - suite: iptables # Fails on GitHub Actions with: ip6tables.service failed
           #   os: fedora-latest
           - suite: iptables
-            os: oracle-8
+            os: oraclelinux-8
           - suite: iptables
             os: rockylinux-8
           - suite: iptables
@@ -150,13 +150,13 @@ jobs:
 
           # NFTables suite
           - suite: nftables
-            os: debian-11
-          - suite: nftables
             os: debian-12
           - suite: nftables
-            os: oracle-8
+            os: debian-13
           - suite: nftables
-            os: oracle-9
+            os: oraclelinux-8
+          - suite: nftables
+            os: oraclelinux-9
 
           # Firewalld advanced suite
           - suite: firewalld-advanced
@@ -172,17 +172,17 @@ jobs:
           - suite: firewalld-advanced
             os: centos-stream-10
           - suite: firewalld-advanced
-            os: debian-11
-          - suite: firewalld-advanced
             os: debian-12
+          - suite: firewalld-advanced
+            os: debian-13
           - suite: firewalld-advanced
             os: fedora-latest
           - suite: firewalld-advanced
             os: opensuse-leap-15
           - suite: firewalld-advanced
-            os: oracle-8
+            os: oraclelinux-8
           - suite: firewalld-advanced
-            os: oracle-9
+            os: oraclelinux-9
           - suite: firewalld-advanced
             os: rockylinux-8
           - suite: firewalld-advanced

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -3,6 +3,7 @@ config:
   line-length: false # MD013
   no-duplicate-heading: false # MD024
   reference-links-images: false # MD052
+  table-column-style: false # MD060
   no-multiple-blanks:
     maximum: 2
 ignores:

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -2,7 +2,7 @@
 
 name 'firewall'
 
-run_list 'firewall::default', 'firewall-test::default'
+run_list 'firewall-test::default'
 
 cookbook 'apt', git: 'https://github.com/sous-chefs/apt.git', branch: 'main'
 cookbook 'firewall', path: '.'
@@ -10,10 +10,10 @@ cookbook 'firewall-test', path: './test/fixtures/cookbooks/firewall-test'
 cookbook 'firewalld-test', path: './test/fixtures/cookbooks/firewalld-test'
 cookbook 'nftables-test', path: './test/fixtures/cookbooks/nftables-test'
 
-named_run_list :default, 'firewall::default', 'firewall-test::default'
-named_run_list :firewalld_simple, 'firewall::default', 'firewall-test::default'
-named_run_list :ufw, 'firewall::default', 'firewall-test::default'
-named_run_list :iptables, 'firewall::default', 'firewall-test::default'
+named_run_list :default, 'firewall-test::default'
+named_run_list :firewalld_simple, 'firewall-test::default'
+named_run_list :ufw, 'firewall-test::default'
+named_run_list :iptables, 'firewall-test::default'
 named_run_list :nftables, 'nftables-test::default'
 named_run_list :firewalld_advanced, 'firewalld-test::default'
-named_run_list :windows, 'firewall::default', 'firewall-test::default'
+named_run_list :windows, 'firewall-test::default'

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+name 'firewall'
+
+run_list 'firewall::default', 'firewall-test::default'
+
+cookbook 'apt', git: 'https://github.com/sous-chefs/apt.git', branch: 'main'
+cookbook 'firewall', path: '.'
+cookbook 'firewall-test', path: './test/fixtures/cookbooks/firewall-test'
+cookbook 'firewalld-test', path: './test/fixtures/cookbooks/firewalld-test'
+cookbook 'nftables-test', path: './test/fixtures/cookbooks/nftables-test'
+
+named_run_list :default, 'firewall::default', 'firewall-test::default'
+named_run_list :firewalld_simple, 'firewall::default', 'firewall-test::default'
+named_run_list :ufw, 'firewall::default', 'firewall-test::default'
+named_run_list :iptables, 'firewall::default', 'firewall-test::default'
+named_run_list :nftables, 'nftables-test::default'
+named_run_list :firewalld_advanced, 'firewalld-test::default'
+named_run_list :windows, 'firewall::default', 'firewall-test::default'

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -4,7 +4,9 @@ driver:
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport: { name: dokken }
-provisioner: { name: dokken }
+provisioner:
+  name: dokken
+  policyfile: Policyfile.rb
 
 platforms:
   - name: almalinux-8

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -1,6 +1,7 @@
 ---
 provisioner:
   name: chef_infra
+  policyfile: Policyfile.rb
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,6 +3,7 @@ driver:
 
 provisioner:
   name: chef_infra
+  policyfile: Policyfile.rb
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] %>
   deprecations_as_errors: true
@@ -44,10 +45,14 @@ platforms:
 
 suites:
   - name: default
+    provisioner:
+      named_run_list: default
     run_list:
       - recipe[firewall-test::default]
 
   - name: firewalld-simple
+    provisioner:
+      named_run_list: firewalld_simple
     excludes:
       - windows-2016
       - windows-2019
@@ -58,6 +63,8 @@ suites:
         solution: firewalld
 
   - name: ufw
+    provisioner:
+      named_run_list: ufw
     excludes:
       - almalinux-10     # UFW not available in EPEL 10 (yet?)
       - amazonlinux-2023 # No EPEL for AL2023
@@ -72,6 +79,8 @@ suites:
         solution: ufw
 
   - name: iptables
+    provisioner:
+      named_run_list: iptables
     excludes:
       - oracle-9         # iptables fails to install from Oracle repo
       - opensuse-leap-15 # openSUSE only supports firewalld
@@ -84,6 +93,8 @@ suites:
         solution: iptables
 
   - name: nftables
+    provisioner:
+      named_run_list: nftables
     includes:
       - debian-11
       - debian-12
@@ -100,10 +111,13 @@ suites:
     run_list:
       - recipe[firewalld-test]
     provisioner:
+      named_run_list: firewalld_advanced
       enforce_idempotency: true
       multiple_converge: 2
 
   - name: windows
+    provisioner:
+      named_run_list: windows
     includes:
       - windows-2016
       - windows-2019

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -25,12 +25,12 @@ platforms:
   - name: amazonlinux-2
   - name: amazonlinux-2023
   - name: centos-stream-9
-  - name: debian-11
   - name: debian-12
+  - name: debian-13
   - name: fedora-latest
   - name: opensuse-leap-15
-  - name: oracle-8
-  - name: oracle-9
+  - name: oraclelinux-8
+  - name: oraclelinux-9
   - name: rockylinux-8
   - name: rockylinux-9
   - name: ubuntu-20.04
@@ -82,7 +82,7 @@ suites:
     provisioner:
       named_run_list: iptables
     excludes:
-      - oracle-9         # iptables fails to install from Oracle repo
+      - oraclelinux-9    # iptables fails to install from Oracle repo
       - opensuse-leap-15 # openSUSE only supports firewalld
       - windows-2016
       - windows-2019
@@ -96,10 +96,10 @@ suites:
     provisioner:
       named_run_list: nftables
     includes:
-      - debian-11
       - debian-12
-      - oracle-8
-      - oracle-9
+      - debian-13
+      - oraclelinux-8
+      - oraclelinux-9
     run_list:
       - recipe[nftables-test]
 

--- a/libraries/provider_firewall_ufw.rb
+++ b/libraries/provider_firewall_ufw.rb
@@ -84,22 +84,33 @@ class Chef
         end
       end
 
-      # ensure a file resource exists with the current ufw rules
-      ufw_file = lookup_or_create_rulesfile
-      ufw_file.content build_rule_file(new_resource.rules['ufw'])
-      ufw_file.run_action(:create)
+      desired_rules = build_rule_file(new_resource.rules['ufw'])
+      return if ::File.exist?(ufw_rules_filename) && ::File.read(ufw_rules_filename) == desired_rules
 
-      # if the file was changed, restart iptables
-      return unless ufw_file.updated_by_last_action?
-      ufw_reset!
-      ufw_logging!(new_resource.log_level) if new_resource.log_level
+      ufw_was_active = ufw_active?
+      begin
+        ufw_reset!
+        ufw_logging!(new_resource.log_level) if new_resource.log_level
 
-      new_resource.rules['ufw'].sort_by { |_k, v| v }.map { |k, _v| k }.each do |cmd|
-        ufw_rule!(cmd)
+        new_resource.rules['ufw'].sort_by { |_k, v| v }.map { |k, _v| k }.each do |cmd|
+          ufw_rule!(cmd)
+        end
+
+        # Ensure it's enabled after rules are inputted, to catch malformed rules.
+        ufw_enable! unless ufw_active?
+      rescue StandardError
+        begin
+          ufw_enable! if ufw_was_active && !ufw_active?
+        rescue StandardError => e
+          Chef::Log.error("Unable to restore UFW after rules replay failed: #{e}")
+        end
+        raise
       end
 
-      # ensure it's enabled _after_ rules are inputted, to catch malformed rules
-      ufw_enable! unless ufw_active?
+      # The rules file is the success marker, so commit it only after the replay.
+      ufw_file = lookup_or_create_rulesfile
+      ufw_file.content desired_rules
+      ufw_file.run_action(:create)
       new_resource.updated_by_last_action(true)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT

--- a/spec/unit/providers/firewall_ufw_spec.rb
+++ b/spec/unit/providers/firewall_ufw_spec.rb
@@ -64,6 +64,19 @@ describe Chef::Provider::FirewallUfw do
     end
   end
 
+  it 'logs a recovery failure and re-raises the original replay exception' do
+    provider = build_provider
+    recovery_error = RuntimeError.new('injected recovery failure')
+    allow(provider).to receive(:ufw_enable!).and_raise(recovery_error)
+    allow(Chef::Log).to receive(:error)
+
+    expect { provider.run_action(:restart) }
+      .to raise_error(Mixlib::ShellOut::ShellCommandFailed, 'injected replay failure')
+
+    expect(Chef::Log).to have_received(:error)
+      .with('Unable to restore UFW after rules replay failed: injected recovery failure')
+  end
+
   it 'retries on the next converge, commits after success, and is then idempotent' do
     expect { build_provider.run_action(:restart) }
       .to raise_error(Mixlib::ShellOut::ShellCommandFailed, 'injected replay failure')

--- a/spec/unit/providers/firewall_ufw_spec.rb
+++ b/spec/unit/providers/firewall_ufw_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../libraries/helpers'
+require_relative '../../../libraries/helpers_ufw'
+require_relative '../../../libraries/resource_firewall'
+require_relative '../../../libraries/provider_firewall_ufw'
+
+describe Chef::Provider::FirewallUfw do
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) do
+    Chef::Resource::Firewall.new('default', run_context).tap do |firewall|
+      firewall.rules('ufw' => { 'ufw allow 22/tcp' => 50 })
+    end
+  end
+  let(:rules_filename) { '/etc/default/ufw-chef.rules' }
+  let(:persisted_rules) { { content: "# previous rules\n", updated: false } }
+  let(:firewall_state) { { active: true } }
+  let(:rule_attempts) { [] }
+  let(:rules_file) { instance_double(Chef::Resource::File) }
+
+  before do
+    pending_content = nil
+
+    allow(Chef).to receive(:run_context).and_return(run_context)
+    allow(::File).to receive(:exist?).and_call_original
+    allow(::File).to receive(:exist?).with(rules_filename).and_return(true)
+    allow(::File).to receive(:read).and_call_original
+    allow(::File).to receive(:read).with(rules_filename).and_wrap_original do |_method, *_args|
+      persisted_rules[:content]
+    end
+
+    allow(rules_file).to receive(:content) { |content| pending_content = content }
+    allow(rules_file).to receive(:run_action).with(:create) do
+      persisted_rules[:updated] = persisted_rules[:content] != pending_content
+      persisted_rules[:content] = pending_content
+    end
+    allow(rules_file).to receive(:updated_by_last_action?) { persisted_rules[:updated] }
+  end
+
+  def build_provider
+    described_class.new(resource, run_context).tap do |provider|
+      allow(provider).to receive(:lookup_or_create_rulesfile).and_return(rules_file)
+      allow(provider).to receive(:ufw_active?) { firewall_state[:active] }
+      allow(provider).to receive(:ufw_reset!) { firewall_state[:active] = false }
+      allow(provider).to receive(:ufw_logging!)
+      allow(provider).to receive(:ufw_enable!) { firewall_state[:active] = true }
+      allow(provider).to receive(:ufw_rule!) do |command|
+        rule_attempts << command
+        raise Mixlib::ShellOut::ShellCommandFailed, 'injected replay failure' if rule_attempts.one?
+      end
+    end
+  end
+
+  it 'does not commit desired rules and restores an active firewall after replay fails' do
+    expect { build_provider.run_action(:restart) }
+      .to raise_error(Mixlib::ShellOut::ShellCommandFailed, 'injected replay failure')
+
+    aggregate_failures do
+      expect(persisted_rules[:content]).to eq("# previous rules\n")
+      expect(firewall_state[:active]).to be(true)
+    end
+  end
+
+  it 'retries on the next converge, commits after success, and is then idempotent' do
+    expect { build_provider.run_action(:restart) }
+      .to raise_error(Mixlib::ShellOut::ShellCommandFailed, 'injected replay failure')
+
+    expect { build_provider.run_action(:restart) }.not_to raise_error
+
+    expect(rule_attempts).to eq(['ufw allow 22/tcp', 'ufw allow 22/tcp'])
+    expect(persisted_rules[:content]).to eq("# position 50\nufw allow 22/tcp\n")
+    expect(firewall_state[:active]).to be(true)
+
+    expect { build_provider.run_action(:restart) }.not_to raise_error
+    expect(rule_attempts).to eq(['ufw allow 22/tcp', 'ufw allow 22/tcp'])
+    expect(rules_file).to have_received(:run_action).with(:create).once
+  end
+end

--- a/test/fixtures/cookbooks/firewall-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/default.rb
@@ -114,6 +114,8 @@ if ufw
   firewall_rule 'ufw raw test' do
     raw 'allow from 192.168.1.1 to 192.168.2.1 port 25 proto tcp'
   end
+
+  include_recipe 'firewall-test::ufw_replay_failure' if platform?('ubuntu')
 end
 
 if iptables

--- a/test/fixtures/cookbooks/firewall-test/recipes/ufw_replay_failure.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/ufw_replay_failure.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+test_root = '/opt/firewall-ufw-replay-test'
+failure_state = "#{test_root}/failure-injected"
+success_state = "#{test_root}/replay-recovered"
+wrapper_path = "#{test_root}/ufw"
+rules_path = '/etc/default/ufw-chef.rules'
+
+directory test_root do
+  recursive true
+end
+
+file wrapper_path do
+  mode '0755'
+  content <<~SH
+    #!/bin/sh
+    set -eu
+
+    if [ "$*" = "allow 54321/tcp" ] && [ ! -e "#{failure_state}" ]; then
+      touch "#{failure_state}"
+      echo "injected UFW replay failure" >&2
+      exit 1
+    fi
+
+    exec /usr/sbin/ufw "$@"
+  SH
+end
+
+execute 'activate ufw before replay failure injection' do
+  command '/usr/sbin/ufw --force enable'
+  not_if "/usr/sbin/ufw status | grep -q '^Status: active'"
+end
+
+firewall_rule 'ufw replay failure probe' do
+  raw 'allow 54321/tcp'
+  notify_firewall false
+end
+
+ruby_block 'verify failed ufw replay remains retryable' do
+  block do
+    firewall_resource = Chef.run_context.resource_collection.find(firewall: 'default')
+    persisted_before_failure = ::File.read(rules_path)
+    original_path = ENV.fetch('PATH')
+    ENV['PATH'] = "#{test_root}:#{original_path}"
+
+    begin
+      replay_failure = nil
+      begin
+        firewall_resource.run_action(:restart)
+      rescue Mixlib::ShellOut::ShellCommandFailed => e
+        replay_failure = e
+      end
+
+      unless replay_failure&.message&.include?('injected UFW replay failure')
+        raise 'UFW replay did not raise the injected failure'
+      end
+
+      unless ::File.read(rules_path) == persisted_before_failure
+        raise 'UFW rules marker changed despite a failed replay'
+      end
+
+      status = Mixlib::ShellOut.new('/usr/sbin/ufw', 'status').run_command
+      status.error!
+      raise 'UFW was not restored after the failed replay' unless status.stdout.match?(/^Status:\s+active/)
+
+      firewall_resource.run_action(:restart)
+    ensure
+      ENV['PATH'] = original_path
+    end
+
+    unless ::File.read(rules_path).include?('ufw allow 54321/tcp')
+      raise 'UFW rules marker was not committed after the successful retry'
+    end
+
+    ::File.write(success_state, "replay retried successfully\n")
+  end
+  not_if { ::File.exist?(success_state) }
+end

--- a/test/integration/iptables/inspec/iptables_spec.rb
+++ b/test/integration/iptables/inspec/iptables_spec.rb
@@ -13,12 +13,8 @@ expected_rules = [
   %r{-A INPUT -s 192.168.99.99(/32)? -p tcp -m tcp .*-j REJECT --reject-with icmp-port-unreachable},
 ]
 
-vrrp_protocol = 'vrrp'
-if %w(redhat suse).include?(os.family) && os.release == '10'
-  # On RHEL 10 iptables-save doesn't show the friendly protocol name, just the
-  # /etc/protocols number
-  vrrp_protocol = '112'
-end
+# iptables-save may render the protocol using its canonical name or number.
+vrrp_protocol = '(?:vrrp|112)'
 
 expected_rules.push(/-A INPUT -p #{vrrp_protocol} .*-j ACCEPT/)
 

--- a/test/integration/ufw/inspec/ufw_spec.rb
+++ b/test/integration/ufw/inspec/ufw_spec.rb
@@ -28,3 +28,18 @@ describe service('ufw') do
     its(:stdout) { should match(/Status: active/) }
   end
 end
+
+if os.name == 'ubuntu'
+  describe file('/opt/firewall-ufw-replay-test/replay-recovered') do
+    it { should exist }
+    its('content') { should match(/replay retried successfully/) }
+  end
+
+  describe file('/etc/default/ufw-chef.rules') do
+    its('content') { should match(%r{ufw allow 54321/tcp}) }
+  end
+
+  describe command('ufw status numbered') do
+    its('stdout') { should match(%r{54321/tcp +ALLOW IN}) }
+  end
+end


### PR DESCRIPTION
## Summary

When a UFW rule update fails, the cookbook now leaves the saved rules marker unchanged. The next Chef run retries the update instead of treating the failed rules as applied.

If the firewall was active before the update, the provider attempts to enable it again after a failure and re-raises the original error. A successful update saves the marker and remains idempotent on later runs.

Closes #218.

## Verification

- `chef install Policyfile.rb`
- `cookstyle` — 59 files, no offences
- ChefSpec — 4 examples, 0 failures
- Ubuntu 24.04 UFW Kitchen/InSpec — 19 successful, 0 failures
- AlmaLinux 9 UFW Kitchen/InSpec — 15 successful, 0 failures
- Provider retry and post-success idempotency coverage
- Independent security review

## Limitation

UFW cannot restore its previous runtime ruleset atomically. If a replay fails after the reset, recovery enables the successfully replayed or default-deny state. This keeps the firewall active without claiming that the old ruleset was restored.
